### PR TITLE
Weak Delegate

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -81,7 +81,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverArrowDirection) {
 {
 }
 
-@property (nonatomic, assign) id <WYPopoverControllerDelegate> delegate;
+@property (nonatomic, weak) id <WYPopoverControllerDelegate> delegate;
 
 @property (nonatomic, copy) NSArray *passthroughViews;
 


### PR DESCRIPTION
Putting your WYPopoverController delegate to weak to avoid having to set it to nil in controller's delegate callback.
