### PR TITLE
Added popoverContentSize property to match UIPopoverController behavior

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -88,6 +88,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverArrowDirection) {
 @property (nonatomic, assign) UIEdgeInsets popoverLayoutMargins;
 @property (nonatomic, assign, readonly) BOOL isPopoverVisible;
 @property (nonatomic, strong, readonly) UIViewController* contentViewController;
+@property (nonatomic, assign) CGSize popoverContentSize;
 
 - (id)initWithContentViewController:(UIViewController *)viewController;
 

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1338,6 +1338,40 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     return result;
 }
 
+- (CGSize)popoverContentSize
+{
+    if ([viewController respondsToSelector:@selector(preferredContentSize)])
+    {
+        return [viewController preferredContentSize];
+    }
+    else if ([viewController respondsToSelector:@selector(contentSizeForViewInPopover:)])
+    {
+#pragma clang diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
+        return [viewController contentSizeForViewInPopover];
+#pragma clang diagnostic pop
+    }
+
+    return CGSizeZero;
+}
+
+- (void)setPopoverContentSize:(CGSize)size
+{
+    if ([viewController respondsToSelector:@selector(setPreferredContentSize:)])
+    {
+        [viewController setPreferredContentSize:size];
+    }
+    else if ([viewController respondsToSelector:@selector(setContentSizeForViewInPopover:)])
+    {
+#pragma clang diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
+        [viewController setContentSizeForViewInPopover:size];
+#pragma clang diagnostic pop
+    }
+    
+    [self positionPopover];
+}
+
 - (CGSize)contentSizeForViewInPopover
 {
     CGSize result = CGSizeZero;


### PR DESCRIPTION
The way WYPopoverController is currently implemented, you cannot change the size of the popover controller dynamically, you have to have set it before the content view controller is initialized.  UIPopoverController has a property, "popoverContentSize" that allows you to change or set the size of the content view anytime, even after its displayed.  I added this property to WYPopoverController to give the same behavior.
