### PR TITLE
Enabling compatibility with other components that are using UIWindow

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1302,9 +1302,12 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
 {
     UIWindow *result = [[UIApplication sharedApplication] keyWindow];
     
-    if (result.subviews.count > 0)
+    if (result.rootViewController)
     {
-        result = [result.subviews lastObject];
+#pragma clang diagnostic push
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
+        result = result.rootViewController.view;
+#pragma clang diagnostic pop
     }
 
     return result;


### PR DESCRIPTION
When other components adds a subview on `UIWindows`' `rootViewController` `WYPopoverController` was showing on component's subview and not on rootViewController's view.
