### PR TITLE
Use popover controller like a custom dialog popup

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -104,6 +104,8 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverArrowDirection) {
                permittedArrowDirections:(WYPopoverArrowDirection)arrowDirections
                                animated:(BOOL)animated;
 
+- (void)presentPopoverAsDialogAnimated:(BOOL)animated;
+
 - (void)dismissPopoverAnimated:(BOOL)animated;
 
 @end

--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -38,6 +38,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverArrowDirection) {
     WYPopoverArrowDirectionDown = 1UL << 1,
     WYPopoverArrowDirectionLeft = 1UL << 2,
     WYPopoverArrowDirectionRight = 1UL << 3,
+    WYPopoverArrowDirectionNone = 1UL << 4,
     WYPopoverArrowDirectionAny = WYPopoverArrowDirectionUp | WYPopoverArrowDirectionDown | WYPopoverArrowDirectionLeft | WYPopoverArrowDirectionRight,
     WYPopoverArrowDirectionUnknown = NSUIntegerMax
 };

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -144,6 +144,10 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
     {
         direction = @"RIGHT";
     }
+    else if (arrowDirection == WYPopoverArrowDirectionNone)
+    {
+        direction = @"NONE";
+    }
     
     return [NSString stringWithFormat:@"%@ [ %f x %f ]", direction, areaSize.width, areaSize.height];
 }
@@ -995,7 +999,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
                 reducedOuterCornerRadius = (CGRectGetMidX(outerRect) + arrowOffset - arrowBase / 2) - CGRectGetMinX(outerRect);
             }
         }
-        else
+        else if (arrowDirection == WYPopoverArrowDirectionLeft || arrowDirection == WYPopoverArrowDirectionRight)
         {
             if (arrowOffset >= 0)
             {
@@ -1073,6 +1077,23 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
             CGPathAddArcToPoint(outerPathRef, NULL, CGRectGetMinX(outerRect), CGRectGetMaxY(outerRect), CGRectGetMinX(outerRect), CGRectGetMinY(outerRect), outerCornerRadius);
             CGPathAddArcToPoint(outerPathRef, NULL, CGRectGetMinX(outerRect), CGRectGetMinY(outerRect), CGRectGetMaxX(outerRect), CGRectGetMinY(outerRect), outerCornerRadius);
             CGPathAddArcToPoint(outerPathRef, NULL, CGRectGetMaxX(outerRect), CGRectGetMinY(outerRect), CGRectGetMaxX(outerRect), CGRectGetMaxY(outerRect), (arrowOffset < 0) ? reducedOuterCornerRadius : outerCornerRadius);
+            
+            CGPathAddLineToPoint(outerPathRef, NULL, origin.x, origin.y);
+        }
+        
+        if (arrowDirection == WYPopoverArrowDirectionNone)
+        {
+            origin = CGPointMake(CGRectGetMaxX(outerRect), CGRectGetMidY(outerRect));
+            
+            CGPathMoveToPoint(outerPathRef, NULL, origin.x, origin.y);
+            
+            CGPathAddLineToPoint(outerPathRef, NULL, CGRectGetMaxX(outerRect), CGRectGetMidY(outerRect));
+            CGPathAddLineToPoint(outerPathRef, NULL, CGRectGetMaxX(outerRect), CGRectGetMidY(outerRect));
+            
+            CGPathAddArcToPoint(outerPathRef, NULL, CGRectGetMaxX(outerRect), CGRectGetMaxY(outerRect), CGRectGetMinX(outerRect), CGRectGetMaxY(outerRect), outerCornerRadius);
+            CGPathAddArcToPoint(outerPathRef, NULL, CGRectGetMinX(outerRect), CGRectGetMaxY(outerRect), CGRectGetMinX(outerRect), CGRectGetMinY(outerRect), outerCornerRadius);
+            CGPathAddArcToPoint(outerPathRef, NULL, CGRectGetMinX(outerRect), CGRectGetMinY(outerRect), CGRectGetMaxX(outerRect), CGRectGetMinY(outerRect), outerCornerRadius);
+            CGPathAddArcToPoint(outerPathRef, NULL, CGRectGetMaxX(outerRect), CGRectGetMinY(outerRect), CGRectGetMaxX(outerRect), CGRectGetMaxY(outerRect), outerCornerRadius);
             
             CGPathAddLineToPoint(outerPathRef, NULL, origin.x, origin.y);
         }
@@ -1821,6 +1842,24 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         containerView.arrowOffset = offset;
     }
     
+    if (arrowDirection == WYPopoverArrowDirectionNone)
+    {
+        containerView.arrowDirection = WYPopoverArrowDirectionNone;
+        containerViewSize = [containerView sizeThatFits:contentViewSize];
+        
+        containerFrame = CGRectZero;
+        containerFrame.size = containerViewSize;
+        containerFrame.size.width = MIN(maxX - minX, containerFrame.size.width);
+        containerFrame.size.height = MIN(maxY - minY, containerFrame.size.height);
+        containerView.frame = containerFrame;
+        
+        containerView.center = CGPointMake(minX + (maxX - minX) / 2, minY + (maxY - minY) / 2);
+        
+        containerFrame = containerView.frame;
+        
+        containerView.arrowOffset = offset;
+    }
+    
     containerView.frame = containerFrame;
     
     containerView.wantsDefaultContentAppearance = wantsDefaultContentAppearance;
@@ -1965,6 +2004,14 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         area.arrowDirection = WYPopoverArrowDirectionRight;
         [areas addObject:area];
     }
+
+    if ((arrowDirections & WYPopoverArrowDirectionNone) == WYPopoverArrowDirectionNone)
+    {
+        area = [[WYPopoverArea alloc] init];
+        area.areaSize = [self sizeForRect:aRect inView:aView arrowHeight:arrowHeight arrowDirection:WYPopoverArrowDirectionNone];
+        area.arrowDirection = WYPopoverArrowDirectionNone;
+        [areas addObject:area];
+    }
     
     if ([areas count] > 1)
     {
@@ -2079,6 +2126,11 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         result.width = maxX - minX;
         result.height = maxY - (viewFrame.origin.y + viewFrame.size.height);
         result.height -= arrowHeight;
+    }
+    else if (arrowDirection == WYPopoverArrowDirectionNone)
+    {
+        result.width = maxX - minX;
+        result.height = maxY - minY;
     }
     
     return result;

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1610,6 +1610,11 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     [self presentPopoverFromRect:itemView.bounds inView:itemView permittedArrowDirections:arrowDirections animated:aAnimated];
 }
 
+- (void)presentPopoverAsDialogAnimated:(BOOL)aAnimated
+{
+    [self presentPopoverFromRect:CGRectZero inView:nil permittedArrowDirections:WYPopoverArrowDirectionNone animated:aAnimated];
+}
+
 - (void)positionPopover
 {
     CGSize contentViewSize = self.contentSizeForViewInPopover;


### PR DESCRIPTION
This request contains two enhancements:
1. Added a None arrow direction type so that no arrow is drawn and so that the popup view is NOT anchored to some rect on the screen.  Instead, the popup view is always centered on the screen
2. Added special presentPopoverAsDialogAnimated: method so that the caller doesn't need to specify a rect to anchor to.  Only the animated boolean is required and the arrow direction is set as None automatically.
