### PR TITLE
Use CGRectIntegral to avoid blurred content

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -763,7 +763,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
 {
     contentView = viewController.view;
     
-    contentView.frame = CGRectMake(0, 0, self.bounds.size.width, 100);
+    contentView.frame = CGRectIntegral(CGRectMake(0, 0, self.bounds.size.width, 100));
     
     [self addSubview:contentView];
     
@@ -775,7 +775,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         navigationBarHeight = navigationController.navigationBar.bounds.size.height;
     }
     
-    contentView.frame = [self innerRect];
+    contentView.frame = CGRectIntegral([self innerRect]);
     
     if (innerView == nil)
     {
@@ -801,7 +801,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
 
     [self insertSubview:innerView aboveSubview:contentView];
     
-    innerView.frame = contentView.frame;
+    innerView.frame = CGRectIntegral(contentView.frame);
     
     [self.layer setNeedsDisplay];
 }
@@ -1707,7 +1707,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         containerFrame.size.width = MIN(maxX - minX, containerFrame.size.width);
         containerFrame.size.height = MIN(maxY - minY, containerFrame.size.height);
         
-        containerView.frame = containerFrame;
+        containerView.frame = CGRectIntegral(containerFrame);
         
         containerView.center = CGPointMake(viewFrame.origin.x + viewFrame.size.width / 2, viewFrame.origin.y + viewFrame.size.height / 2);
         
@@ -1806,7 +1806,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         containerFrame.size.width = MIN(maxX - minX, containerFrame.size.width);
         containerFrame.size.height = MIN(maxY - minY, containerFrame.size.height);
         
-        containerView.frame = containerFrame;
+        containerView.frame = CGRectIntegral(containerFrame);
         
         containerView.center = CGPointMake(viewFrame.origin.x + viewFrame.size.width / 2, viewFrame.origin.y + viewFrame.size.height / 2);
         
@@ -1861,7 +1861,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         
         containerView.center = CGPointMake(viewFrame.origin.x + viewFrame.size.width / 2, viewFrame.origin.y + viewFrame.size.height / 2);
         
-        containerFrame = containerView.frame;
+        containerFrame = CGRectIntegral(containerView.frame);
         
         offset = containerView.frame.size.width / 2 + viewFrame.size.width / 2 - containerView.outerShadowInsets.left;
         
@@ -1905,7 +1905,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         containerFrame.size = containerViewSize;
         containerFrame.size.width = MIN(maxX - minX, containerFrame.size.width);
         containerFrame.size.height = MIN(maxY - minY, containerFrame.size.height);
-        containerView.frame = containerFrame;
+        containerView.frame = CGRectIntegral(containerFrame);
         
         containerView.center = CGPointMake(minX + (maxX - minX) / 2, minY + (maxY - minY) / 2);
         
@@ -1914,7 +1914,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         containerView.arrowOffset = offset;
     }
     
-    containerView.frame = containerFrame;
+    containerView.frame = CGRectIntegral(containerFrame);
     
     containerView.wantsDefaultContentAppearance = wantsDefaultContentAppearance;
     


### PR DESCRIPTION
When containerView frame has non integer values, the content appears blurred. Using CGRectIntegral allows to easily avoid this.
