### PR TITLE
Update WYPopoverController.m

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1415,7 +1415,12 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     
     if (result.subviews.count > 0)
     {
-        result = [result.subviews lastObject];
+	for (UIView *view in result.subviews) {
+		if(!view.isHidden){
+			return view;
+		}
+	}
+//        result = [result.subviews lastObject];
     }
 
     return result;


### PR DESCRIPTION
Fix issue #47
window may has a background subview while it's hidden, that cause the popover can not be shown up.
