### PR TITLE
Determine content size with nav's visible controller

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1478,10 +1478,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     {
         UINavigationController *navigationController = (UINavigationController *)controller;
         
-        if ([[navigationController viewControllers] count] > 0)
-        {
-            controller = (UIViewController *)[[navigationController viewControllers] objectAtIndex:0];
-        }
+        controller = [navigationController visibleViewController];
     }
     
 #ifdef WY_BASE_SDK_7_ENABLED


### PR DESCRIPTION
I was having some trouble changing the popover's content size when used with a navigation controller. (#26)

The popover was using only the first viewcontroller in its navigation stack to determine the content size, rather than the currently visible one. But no longer!
