### PR TITLE
adding popover completion block

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -127,6 +127,14 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
                       animated:(BOOL)animated
                        options:(WYPopoverAnimationOptions)options;
 
+- (void)presentPopoverFromRect:(CGRect)rect
+                        inView:(UIView *)view
+      permittedArrowDirections:(WYPopoverArrowDirection)arrowDirections
+                      animated:(BOOL)animated
+                       options:(WYPopoverAnimationOptions)options
+                    completion:(void (^)(void))completion;
+
+
 - (void)presentPopoverFromBarButtonItem:(UIBarButtonItem *)item
                permittedArrowDirections:(WYPopoverArrowDirection)arrowDirections
                                animated:(BOOL)animated

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1509,6 +1509,21 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
                       animated:(BOOL)aAnimated
                        options:(WYPopoverAnimationOptions)aOptions
 {
+    [self presentPopoverFromRect:aRect
+                          inView:aView
+        permittedArrowDirections:arrowDirections
+                        animated:aAnimated
+                         options:aOptions
+                      completion:nil];
+}
+
+- (void)presentPopoverFromRect:(CGRect)aRect
+                        inView:(UIView *)aView
+      permittedArrowDirections:(WYPopoverArrowDirection)arrowDirections
+                      animated:(BOOL)aAnimated
+                       options:(WYPopoverAnimationOptions)aOptions
+                    completion:(void (^)(void))completion
+{
     NSAssert((arrowDirections != WYPopoverArrowDirectionUnknown), @"WYPopoverArrowDirection must not be UNKNOWN");
     
     rect = aRect;
@@ -1609,6 +1624,11 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
             {
                 [viewController viewDidAppear:YES];
             }
+            
+            if (completion)
+            {
+                completion();
+            }
         }];
     }
     else
@@ -1618,6 +1638,11 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
         if ([viewController isKindOfClass:[UINavigationController class]] == NO)
         {
             [viewController viewDidAppear:NO];
+        }
+        
+        if (completion)
+        {
+            completion();
         }
     }
     


### PR DESCRIPTION
While the UIPopoverController API lacks completion blocks, I had a case where such a thing was useful (needed it to happen after the animations, and an in-class completion block would be the best way to accomplish that with timing and all). So, here we are.

I only added it to the `-presentPopoverFromRect:` because that's all I needed, but if this is added it'd probably be best to flesh out the other `present` methods too.
