### PR TITLE
Added `animationDampingRatio` property.

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -34,6 +34,10 @@
     #define WY_POPOVER_DEFAULT_ANIMATION_DURATION    .25f
 #endif
 
+#ifndef WY_POPOVER_DEFAULT_ANIMATION_DAMPING_RATIO
+    #define WY_POPOVER_DEFAULT_ANIMATION_DAMPING_RATIO 1.0f
+#endif
+
 #ifndef WY_POPOVER_MIN_SIZE
     #define WY_POPOVER_MIN_SIZE                      CGSizeMake(240, 160)
 #endif
@@ -102,6 +106,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, strong, readonly) UIViewController       *contentViewController;
 @property (nonatomic, assign) CGSize                            popoverContentSize;
 @property (nonatomic, assign) float                             animationDuration;
+@property (nonatomic, assign) float                             animationDampingRatio;
 
 @property (nonatomic, strong) WYPopoverTheme                   *theme;
 

--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -38,6 +38,10 @@
     #define WY_POPOVER_DEFAULT_ANIMATION_DAMPING_RATIO 1.0f
 #endif
 
+#ifndef WY_POPOVER_DEFAULT_ANIMATION_INITIAL_VELOCITY
+    #define WY_POPOVER_DEFAULT_ANIMATION_INITIAL_VELOCITY 1.0f
+#endif
+
 #ifndef WY_POPOVER_MIN_SIZE
     #define WY_POPOVER_MIN_SIZE                      CGSizeMake(240, 160)
 #endif
@@ -107,6 +111,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, assign) CGSize                            popoverContentSize;
 @property (nonatomic, assign) float                             animationDuration;
 @property (nonatomic, assign) float                             animationDampingRatio;
+@property (nonatomic, assign) float                             animationInitialVelocity;
 
 @property (nonatomic, strong) WYPopoverTheme                   *theme;
 

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1596,6 +1596,7 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
 @synthesize popoverContentSize = popoverContentSize_;
 @synthesize animationDuration;
 @synthesize animationDampingRatio;
+@synthesize animationInitialVelocity;
 @synthesize theme;
 
 static WYPopoverTheme *defaultTheme_ = nil;
@@ -1651,6 +1652,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
         keyboardRect = CGRectZero;
         animationDuration = WY_POPOVER_DEFAULT_ANIMATION_DURATION;
         animationDampingRatio = WY_POPOVER_DEFAULT_ANIMATION_DAMPING_RATIO;
+        animationInitialVelocity = WY_POPOVER_DEFAULT_ANIMATION_INITIAL_VELOCITY;
         
         themeUpdatesEnabled = NO;
         
@@ -2012,9 +2014,10 @@ static WYPopoverTheme *defaultTheme_ = nil;
         };
 
 #ifdef WY_BASE_SDK_7_ENABLED
-        if ([UIView respondsToSelector:@selector(animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:)]) {
-            CGFloat initialSpringVelocity = 100.0 / fmax(backgroundView.frame.size.height, backgroundView.frame.size.width);
-            [UIView animateWithDuration:animationDuration delay:0 usingSpringWithDamping:animationDampingRatio initialSpringVelocity:initialSpringVelocity options:0 animations:animationBlock completion:^(BOOL finished) {
+        if ((animationInitialVelocity != WY_POPOVER_DEFAULT_ANIMATION_INITIAL_VELOCITY ||
+             animationDampingRatio != WY_POPOVER_DEFAULT_ANIMATION_DAMPING_RATIO) &&
+            [UIView respondsToSelector:@selector(animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:)]) {
+            [UIView animateWithDuration:animationDuration delay:0 usingSpringWithDamping:animationDampingRatio initialSpringVelocity:animationInitialVelocity options:0 animations:animationBlock completion:^(BOOL finished) {
                 completionBlock(YES);
             }];
         } else {

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1595,6 +1595,7 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
 @synthesize popoverLayoutMargins;
 @synthesize popoverContentSize = popoverContentSize_;
 @synthesize animationDuration;
+@synthesize animationDampingRatio;
 @synthesize theme;
 
 static WYPopoverTheme *defaultTheme_ = nil;
@@ -1649,6 +1650,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
         popoverLayoutMargins = UIEdgeInsetsMake(10, 10, 10, 10);
         keyboardRect = CGRectZero;
         animationDuration = WY_POPOVER_DEFAULT_ANIMATION_DURATION;
+        animationDampingRatio = WY_POPOVER_DEFAULT_ANIMATION_DAMPING_RATIO;
         
         themeUpdatesEnabled = NO;
         
@@ -1998,7 +2000,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
             backgroundView.transform = startTransform;
         }
         
-        [UIView animateWithDuration:animationDuration animations:^{
+        void (^animationBlock)() = ^() {
             __typeof__(self) strongSelf = weakSelf;
             
             if (strongSelf)
@@ -2007,9 +2009,21 @@ static WYPopoverTheme *defaultTheme_ = nil;
                 strongSelf->backgroundView.alpha = 1;
                 strongSelf->backgroundView.transform = endTransform;
             }
-        } completion:^(BOOL finished) {
-            completionBlock(YES);
-        }];
+        };
+
+#ifdef WY_BASE_SDK_7_ENABLED
+        if ([UIView respondsToSelector:@selector(animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:)]) {
+            [UIView animateWithDuration:animationDuration delay:0 usingSpringWithDamping:animationDampingRatio initialSpringVelocity:(100.0/backgroundView.frame.size.height) options:0 animations:animationBlock completion:^(BOOL finished) {
+                completionBlock(YES);
+            }];
+        } else {
+#endif
+            [UIView animateWithDuration:animationDuration animations:animationBlock completion:^(BOOL finished) {
+                completionBlock(YES);
+            }];
+#ifdef WY_BASE_SDK_7_ENABLED
+        }
+#endif
     }
     else
     {

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2013,7 +2013,8 @@ static WYPopoverTheme *defaultTheme_ = nil;
 
 #ifdef WY_BASE_SDK_7_ENABLED
         if ([UIView respondsToSelector:@selector(animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:)]) {
-            [UIView animateWithDuration:animationDuration delay:0 usingSpringWithDamping:animationDampingRatio initialSpringVelocity:(100.0/backgroundView.frame.size.height) options:0 animations:animationBlock completion:^(BOOL finished) {
+            CGFloat initialSpringVelocity = 100.0 / fmax(backgroundView.frame.size.height, backgroundView.frame.size.width);
+            [UIView animateWithDuration:animationDuration delay:0 usingSpringWithDamping:animationDampingRatio initialSpringVelocity:initialSpringVelocity options:0 animations:animationBlock completion:^(BOOL finished) {
                 completionBlock(YES);
             }];
         } else {

--- a/demos/Demo/WYPopoverDemo/WYAllDirectionsViewController.m
+++ b/demos/Demo/WYPopoverDemo/WYAllDirectionsViewController.m
@@ -122,7 +122,8 @@
         settingsPopoverController.popoverLayoutMargins = UIEdgeInsetsMake(10, 10, 10, 10);
         settingsPopoverController.wantsDefaultContentAppearance = NO;
         if (sender == topButton) {
-            settingsPopoverController.animationDampingRatio = 0.8f;
+            settingsPopoverController.animationDampingRatio = 0.6f;
+            settingsPopoverController.animationInitialVelocity = 0.0f;
         }
         
         [settingsPopoverController presentPopoverFromRect:btn.bounds

--- a/demos/Demo/WYPopoverDemo/WYAllDirectionsViewController.m
+++ b/demos/Demo/WYPopoverDemo/WYAllDirectionsViewController.m
@@ -121,6 +121,9 @@
         settingsPopoverController.passthroughViews = @[btn];
         settingsPopoverController.popoverLayoutMargins = UIEdgeInsetsMake(10, 10, 10, 10);
         settingsPopoverController.wantsDefaultContentAppearance = NO;
+        if (sender == topButton) {
+            settingsPopoverController.animationDampingRatio = 0.8f;
+        }
         
         [settingsPopoverController presentPopoverFromRect:btn.bounds
                                                    inView:btn


### PR DESCRIPTION
This value is used at `[UIView animateWithDuration:delay:usingSpringWithDamping:initialSpringVelocity:options:animations:completion:`
Default value is 1.0f and no spring damping is animated.

The 'T' button of demo application has 0.6f to show spring damping animation.
