### PR TITLE
stroke color not transparent on iOS 7

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -482,8 +482,8 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
     WYPopoverTheme *result = [[WYPopoverTheme alloc] init];
     
     result.tintColor = [UIColor colorWithRed:244./255. green:244./255. blue:244./255. alpha:1.0];
-    result.outerStrokeColor = [UIColor clearColor];
-    result.innerStrokeColor = [UIColor clearColor];
+    result.outerStrokeColor = nil;
+    result.innerStrokeColor = nil;
     result.fillTopColor = nil;
     result.fillBottomColor = nil;
     result.glossShadowColor = nil;


### PR DESCRIPTION
With dark background I can see that outer stroke color is not transparent:
![sc](https://cloud.githubusercontent.com/assets/3737798/2865208/e3381044-d219-11e3-9abf-3c4eaefc2a96.PNG)

example project: https://github.com/mkutgt72/PopoverProblem.git

btw how to change outerStrokeColor for popover instance (see example for more details)?
