### PR TITLE
Animate Popover alpha on device rotation so rotation isn't as harsh. Mimic's Apple's approach to handing rotation animation. 

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1547,7 +1547,6 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
     WYPopoverArrowDirection  permittedArrowDirections;
     BOOL                     animated;
     BOOL                     isListeningNotifications;
-    BOOL                     isInterfaceOrientationChanging;
     __weak UIBarButtonItem  *barButtonItem;
     CGRect                   keyboardRect;
     
@@ -3064,15 +3063,11 @@ static CGPoint WYPointRelativeToOrientation(CGPoint origin, CGSize size, UIInter
 
 - (void)didChangeStatusBarOrientation:(NSNotification *)notification
 {
-    isInterfaceOrientationChanging = YES;
+    [backgroundView setAlpha:0.0];
 }
 
 - (void)didChangeDeviceOrientation:(NSNotification *)notification
 {
-    if (isInterfaceOrientationChanging == NO) return;
-    
-    isInterfaceOrientationChanging = NO;
-    
     if ([viewController isKindOfClass:[UINavigationController class]])
     {
         UINavigationController* navigationController = (UINavigationController*)viewController;
@@ -3108,6 +3103,10 @@ static CGPoint WYPointRelativeToOrientation(CGPoint origin, CGSize size, UIInter
     }
     
     [self positionPopover:NO];
+    
+    [UIView animateWithDuration:0.2f delay:0.4f options:0 animations:^{
+        [backgroundView setAlpha:1.0f];
+    } completion:nil];
 }
 
 - (void)keyboardWillShow:(NSNotification *)notification


### PR DESCRIPTION
Removed the guard that caused the popover to get "stuck" in the wrong position when rotating very quickly. This occurred because two didChangeStatusBarOrientation events would fire and then two didChangeDeviceOrientation events instead of interweaving them.

Animate the popover's alpha in and out on rotation so the animation isn't as harsh.
