### PR TITLE
Visible alpha

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -86,7 +86,6 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, assign) UIEdgeInsets viewContentInsets    UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, strong) UIColor *overlayColor             UI_APPEARANCE_SELECTOR;
-
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -246,6 +245,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, assign) UIEdgeInsets viewContentInsets;
 
 @property (nonatomic, strong) UIColor *overlayColor;
+@property (nonatomic, readwrite) CGFloat visibleAlpha;
 
 + (instancetype)theme;
 + (instancetype)themeForIOS6;

--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -102,7 +102,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, strong, readonly) UIViewController       *contentViewController;
 @property (nonatomic, assign) CGSize                            popoverContentSize;
 @property (nonatomic, assign) float                             animationDuration;
-
+@property (nonatomic, assign, getter = isOverlayEnabled) BOOL   overlayEnabled;
 @property (nonatomic, strong) WYPopoverTheme                   *theme;
 
 + (void)setDefaultTheme:(WYPopoverTheme *)theme;

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -31,7 +31,7 @@
 #define WY_BASE_SDK_7_ENABLED
 #endif
 
-#ifdef DEBUG
+#if defined(DEBUG) && !WYPOPOVER_NOLOG
 #define WY_LOG(fmt, ...)		NSLog((@"%s (%d) : " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
 #else
 #define WY_LOG(...)
@@ -433,6 +433,7 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
 @synthesize viewContentInsets;
 
 @synthesize overlayColor;
+@synthesize visibleAlpha;
 
 + (id)theme {
     
@@ -473,6 +474,7 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
     result.innerCornerRadius = 6;
     result.viewContentInsets = UIEdgeInsetsMake(3, 0, 0, 0);
     result.overlayColor = [UIColor clearColor];
+    result.visibleAlpha = 1.0f;
     
     return result;
 }
@@ -503,7 +505,8 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
     result.innerCornerRadius = 0;
     result.viewContentInsets = UIEdgeInsetsZero;
     result.overlayColor = [UIColor colorWithWhite:0 alpha:0.15];
-    
+    result.visibleAlpha = 1.0f;
+
     return result;
 }
 
@@ -595,7 +598,8 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
 }
 
 - (NSArray *)observableKeypaths {
-    return [NSArray arrayWithObjects:@"tintColor", @"outerStrokeColor", @"innerStrokeColor", @"fillTopColor", @"fillBottomColor", @"glossShadowColor", @"glossShadowOffset", @"glossShadowBlurRadius", @"borderWidth", @"arrowBase", @"arrowHeight", @"outerShadowColor", @"outerShadowBlurRadius", @"outerShadowOffset", @"outerCornerRadius", @"innerShadowColor", @"innerShadowBlurRadius", @"innerShadowOffset", @"innerCornerRadius", @"viewContentInsets", @"overlayColor", nil];
+    return [NSArray arrayWithObjects:@"tintColor", @"outerStrokeColor", @"innerStrokeColor", @"fillTopColor", @"fillBottomColor", @"glossShadowColor", @"glossShadowOffset", @"glossShadowBlurRadius", @"borderWidth", @"arrowBase", @"arrowHeight", @"outerShadowColor", @"outerShadowBlurRadius", @"outerShadowOffset", @"outerCornerRadius", @"innerShadowColor", @"innerShadowBlurRadius", @"innerShadowOffset", @"innerCornerRadius", @"viewContentInsets", @"overlayColor",
+            @"visibleAlpha", nil];
 }
 
 @end
@@ -2017,8 +2021,8 @@ static WYPopoverTheme *defaultTheme_ = nil;
             
             if (strongSelf)
             {
-                strongSelf->overlayView.alpha = 1;
-                strongSelf->backgroundView.alpha = 1;
+                strongSelf->overlayView.alpha = theme.visibleAlpha;
+                strongSelf->backgroundView.alpha = theme.visibleAlpha;
                 strongSelf->backgroundView.transform = endTransform;
             }
             adjustTintDimmed();
@@ -2938,7 +2942,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
 }
 
 #pragma mark Inline functions
-
+#if 0
 static NSString* WYStringFromOrientation(NSInteger orientation) {
     NSString *result = @"Unknown";
     
@@ -2961,6 +2965,7 @@ static NSString* WYStringFromOrientation(NSInteger orientation) {
     
     return result;
 }
+#endif
 
 static float WYStatusBarHeight() {
     UIInterfaceOrientation orienation = [[UIApplication sharedApplication] statusBarOrientation];

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1684,6 +1684,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
         themeUpdatesEnabled = YES;
         
         popoverContentSize_ = CGSizeZero;
+        self.overlayEnabled = YES;
     }
     
     return self;
@@ -1935,7 +1936,9 @@ static WYPopoverTheme *defaultTheme_ = nil;
         backgroundView.hidden = YES;
         
         [inView.window addSubview:backgroundView];
-        [inView.window insertSubview:overlayView belowSubview:backgroundView];
+        if( self.isOverlayEnabled ) {
+            [inView.window insertSubview:overlayView belowSubview:backgroundView];
+        }
     }
     
     [self updateThemeUI];


### PR DESCRIPTION
(I'm new to contributing to github, so hopefully I'm doing this right.)

Here's another that allows configuring the alpha level when the popover is visible.

I actually needed this because there's a noticeable "stutter" in my app when initializing the popover.  So I'm using this with an alpha of 0.0f to cache the internal images/views/etc.

Oh, it looks like another thing got snuck in here... If you "#define WYPOPOVER_NOLOG 1" in your pch file, you can disable only the WYPOPOVER logs.  This should not affect the previous way logging behaved if not defined, however.
