### PR TITLE
Fix navigation controller background problem

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2538,6 +2538,8 @@ static WYPopoverTheme *defaultTheme_ = nil;
         backgroundView.frame = containerFrame;
     }
     
+    [backgroundView setNeedsDisplay];
+    
     WY_LOG(@"popoverContainerView.frame = %@", NSStringFromCGRect(backgroundView.frame));
 }
 


### PR DESCRIPTION
Navigation controller in wypopover does not redraw its background view after
view transition. When the sizes of view controllers is different, the background of wypopover will be resized, which is abnormal. 

![2014-09-18 10 33 23](https://cloud.githubusercontent.com/assets/1281311/4314351/7c5ca76e-3edd-11e4-9f48-fd61e75bf6a9.png)
![2014-09-18 10 33 34](https://cloud.githubusercontent.com/assets/1281311/4314350/7c5c8e8c-3edd-11e4-80e4-d8dffc984c60.png)

The image above is the result of view scaling up. If the view size dwindle, the top inner radius will be disappeared. It's not obvious, but this is still a problem.
![2014-09-18 10 33 23](https://cloud.githubusercontent.com/assets/1281311/4314456/9a4c1ca8-3edf-11e4-9dc7-d666e637ab6a.png)

To fix this problem, I add setNeedsDisplay at end of -(void)positionPopover:(BOOL)aAnimated. Then the problem fixed.

![2014-09-18 10 47 03](https://cloud.githubusercontent.com/assets/1281311/4314376/22802c4c-3ede-11e4-9fc5-336350090187.png)
![2014-09-18 10 47 09](https://cloud.githubusercontent.com/assets/1281311/4314377/228242b6-3ede-11e4-8d56-673c424485fc.png)
