### PR TITLE
fixed the sizzled_setPreferredContentSize rentrant loop bug

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -317,7 +317,8 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
     {
 #ifdef WY_BASE_SDK_7_ENABLED
         if ([self respondsToSelector:@selector(setPreferredContentSize:)]) {
-            [self.navigationController setPreferredContentSize:aSize];
+//            [self.navigationController setPreferredContentSize:aSize];
+            [self.navigationController sizzled_setPreferredContentSize:aSize];
         }
 #endif
     }


### PR DESCRIPTION
Wrong method was getting called. After some research on swizzling, I found that this method should be called instead.
